### PR TITLE
Add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,68 @@
+name: Build and deploy website
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Test and build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build website
+        run: npm run build
+
+      - name: Configure GitHub Pages
+        if: github.event_name != 'pull_request'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: dist
+
+  deploy:
+    name: Deploy to production
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -18,4 +18,15 @@ npm run dev
 - `npm test` runs the test suite once.
 - `npm run build` creates an optimized production build in `dist/`.
 - `npm run preview` serves the production build locally.
-- `npm run deploy` publishes `dist/` to GitHub Pages.
+
+## Deployment
+
+The `Build and deploy website` GitHub Actions workflow is the production path:
+
+- Pull requests into `master` must install, test, and build successfully.
+- A merge or direct push to `master` repeats those checks and deploys `dist/` to GitHub Pages.
+- Manual workflow runs can deploy only when run from `master`.
+
+One repository setting is required when enabling the workflow: under **Settings → Pages → Build and deployment**, set **Source** to **GitHub Actions**.
+
+The legacy `npm run deploy` command is retained temporarily as a rollback path while the Actions migration is being verified.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that tests and builds pull requests into `master`
- deploy successful `master` builds through the protected `github-pages` environment
- preserve the custom domain in the generated Pages artifact
- document the new deployment path and retain the legacy command temporarily for rollback

## Validation
- `npm test`
- `npm run build`
- workflow YAML syntax validation
- confirmed `dist/CNAME` contains `scottfoggo.com`

GitHub Pages has already been configured to use **GitHub Actions** as its publishing source.